### PR TITLE
hotfix(prealpha-1126): footer tab stretched fully

### DIFF
--- a/src/app/theme/responsive.scss
+++ b/src/app/theme/responsive.scss
@@ -283,8 +283,6 @@ $breakpoint-5xl: 1600px; // Max desktop
       display: flex !important;
       visibility: visible !important;
       opacity: 1 !important;
-      max-width: 1200px;
-      margin: 0 auto;
       width: 100%;
     }
 


### PR DESCRIPTION
removed 1200px max width constraints, eliminated centered margin (pushed tabs away from screen edges) kept shadow effects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted tab bar layout to display at full width on medium-sized screens and larger displays, removing previous width constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->