### PR TITLE
fixed tab-stretch

### DIFF
--- a/src/app/theme/responsive.scss
+++ b/src/app/theme/responsive.scss
@@ -283,8 +283,7 @@ $breakpoint-5xl: 1600px; // Max desktop
       display: flex !important;
       visibility: visible !important;
       opacity: 1 !important;
-      max-width: 1200px;
-      margin: 0 auto;
+      // Removed max-width and margin to allow tab bar to stretch edge-to-edge on desktop, addressing footer/tab stretch issue.
       width: 100%;
     }
 


### PR DESCRIPTION
Issue is resolved:
- removed max-width and margin to allow tab bar to stretch edge-to-edge on desktop, addressing footer/tab stretch issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tab bar layout to stretch full width on desktop displays instead of being constrained to a fixed maximum width.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->